### PR TITLE
Issue46

### DIFF
--- a/libtocc/src/libtocc/exprs/fields.cpp
+++ b/libtocc/src/libtocc/exprs/fields.cpp
@@ -166,7 +166,7 @@ namespace libtocc
 
   std::string Title::get_field_name()
   {
-    return "$record.$title";
+    return "$record.title";
   }
 
 };

--- a/libtocc/tests/front_end/query_files_tests.cpp
+++ b/libtocc/tests/front_end/query_files_tests.cpp
@@ -18,6 +18,7 @@
 
 #include <catch.hpp>
 #include <fstream>
+#include <string.h>
 
 #include "libtocc/front_end/manager.h"
 #include "libtocc/front_end/file_info.h"
@@ -114,7 +115,7 @@ TEST_CASE("query_files_tests: simple title search")
     // Checking if it's the same file.
     libtocc::FileInfoCollection::Iterator iterator(&founded_files);
     const libtocc::FileInfo* founded_file = iterator.get();
-    REQUIRE(founded_file->get_title() == "IMG007");
-    REQUIRE(founded_file->get_id() == original_file.get_id());
+    REQUIRE(strcmp(founded_file->get_title(), "IMG007") == 0);
+    REQUIRE(strcmp(founded_file->get_id(), original_file.get_id()) == 0);
   }
 }


### PR DESCRIPTION
You've added a '$' character in the wrong place ^^.
In the file "front_end/file query_files_tests.cpp",  FileInfo.get_title() and FileInfo.get_id() functions return a "const char_" type variable, and to compare "char_" variables we need the C function "strcmp".
I think this functionality should be added to  tocc v0.3.0 release. what do you think ? 
