### PR TITLE
issue58

### DIFF
--- a/cli/src/selectors/query_selector.cpp
+++ b/cli/src/selectors/query_selector.cpp
@@ -375,7 +375,6 @@ namespace tocccli
       // Auto release this pointer.
       expr_pointer_holder.add(operand);
 
-      index++;
       if (index >= arguments.size())
       {
         // End of the string. Adding the operand to the previous operator.
@@ -403,6 +402,7 @@ namespace tocccli
         {
           last_operator.second->add((libtocc::FieldExpr&)*operand);
         }
+        index++;
       }
       else
       {


### PR DESCRIPTION
the function "extract_next_operand()" in file query_selector.cpp ends with the variable "index" incremented, therefore when you increment it once again the index won't be pointing on the operator ("and" or "or") but the next next field (tag or title , ...)
