### PR TITLE
fixed issue #43

### DIFF
--- a/libtocc/tests/database/database_basic_tests.cpp
+++ b/libtocc/tests/database/database_basic_tests.cpp
@@ -27,7 +27,7 @@
 TEST_CASE("database: basic tests")
 {
   // Creating the database.
-  libtocc::Database db("/tmp/tocc.test.db");
+  libtocc::Database db("/tmp/tocctests/tocc.test.db");
 
   // Creating a file with no property.
   libtocc::IntFileInfo new_file_1 = db.create_file();

--- a/libtocc/tests/database/find_empty_id_tests.cpp
+++ b/libtocc/tests/database/find_empty_id_tests.cpp
@@ -28,7 +28,7 @@
 TEST_CASE("database: find empty ID")
 {
   // Creating the database.
-  libtocc::Database db("/tmp/tocc.test.db");
+  libtocc::Database db("/tmp/tocctests/tocc.test.db");
 
   // Creating files
   libtocc::IntFileInfo new_file_1 = db.create_file("file__1", "/old/path");

--- a/libtocc/tests/database/get_file_tests.cpp
+++ b/libtocc/tests/database/get_file_tests.cpp
@@ -23,7 +23,7 @@
 TEST_CASE("database: get file tests")
 {
   // Creating the database.
-  libtocc::Database db("/tmp/tocc.test.db");
+  libtocc::Database db("/tmp/tocctests/tocc.test.db");
 
   // Getting a not-existed file.
   REQUIRE_THROWS(db.get("ffr98a0"));

--- a/libtocc/tests/database/tag_operation_tests.cpp
+++ b/libtocc/tests/database/tag_operation_tests.cpp
@@ -27,7 +27,7 @@
 
 TEST_CASE("database: tag operation tests")
 {
-  libtocc::Database db("/tmp/tocc.test.db");
+  libtocc::Database db("/tmp/tocctests/tocc.test.db");
 
   SECTION("Assigning a single tag")
   {

--- a/libtocc/tests/engine/files_engine_tests.cpp
+++ b/libtocc/tests/engine/files_engine_tests.cpp
@@ -31,8 +31,8 @@ TEST_CASE("engine: files engine tests")
   /*
    * Creating instance of files engine.
    */
-  libtocc::Database db("/tmp/tocc.test.db");
-  libtocc::FileManager file_manager("/tmp/");
+  libtocc::Database db("/tmp/tocctests/tocc.test.db");
+  libtocc::FileManager file_manager("/tmp/tocctests/");
   libtocc::TagsEngine tags_engine(&db);
   libtocc::FilesEngine files_engine(&db, &file_manager, &tags_engine);
 
@@ -41,12 +41,12 @@ TEST_CASE("engine: files engine tests")
    */
   // Creating a test file to import.
   std::ofstream file_stream;
-  file_stream.open("/tmp/tocc_a_file_to_import");
+  file_stream.open("/tmp/tocctests/tocc_a_file_to_import");
   file_stream << "some data...";
   file_stream.close();
 
   // Copying the file.
-  libtocc::IntFileInfo first_file = files_engine.import_file("/tmp/tocc_a_file_to_import");
+  libtocc::IntFileInfo first_file = files_engine.import_file("/tmp/tocctests/tocc_a_file_to_import");
   // Checking if it's OK.
   REQUIRE(first_file.get_title() == "tocc_a_file_to_import");
   REQUIRE(first_file.get_traditional_path() == "");

--- a/libtocc/tests/engine/tags_engine_tests.cpp
+++ b/libtocc/tests/engine/tags_engine_tests.cpp
@@ -26,7 +26,7 @@
 TEST_CASE("engine: tags engine tests")
 {
   // Creating instance of engine.
-  libtocc::Database db("/tmp/tocc.test.db");
+  libtocc::Database db("/tmp/tocctests/tocc.test.db");
   libtocc::TagsEngine tags_engine(&db);
 
   // Assigning some tags.

--- a/libtocc/tests/file_system/file_system_basic_tests.cpp
+++ b/libtocc/tests/file_system/file_system_basic_tests.cpp
@@ -30,9 +30,9 @@
 
 TEST_CASE("file_system: basic tests")
 {
-  std::string base_path = "/tmp/";
+  std::string base_path = "/tmp/tocctests/";
   std::string file_id = "t00f4ia";
-  std::string equivalent_path = "/tmp/t/00/fa/ia";
+  std::string equivalent_path = "/tmp/tocctests/t/00/fa/ia";
   libtocc::FileManager file_manager(base_path);
 
   /*
@@ -72,10 +72,10 @@ TEST_CASE("file_system: basic tests")
    */
   // Creating a test file to copy.
   std::ofstream file_stream;
-  file_stream.open("/tmp/tocc_test_file_to_copy");
+  file_stream.open("/tmp/tocctests/tocc_test_file_to_copy");
   file_stream << "some data...";
   file_stream.close();
 
   // Coping the file.
-  file_manager.copy("/tmp/tocc_test_file_to_copy", "ta59800");
+  file_manager.copy("/tmp/tocctests/tocc_test_file_to_copy", "ta59800");
 }

--- a/libtocc/tests/front_end/front_end_assign_tag_tests.cpp
+++ b/libtocc/tests/front_end/front_end_assign_tag_tests.cpp
@@ -23,7 +23,7 @@
 
 TEST_CASE("front_end: assign tag")
 {
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   manager.assign_tags("0000001", "author:Unknown");
 

--- a/libtocc/tests/front_end/front_end_assign_tag_wrong_tests.cpp
+++ b/libtocc/tests/front_end/front_end_assign_tag_wrong_tests.cpp
@@ -27,7 +27,7 @@
  */
 TEST_CASE("front_end: assign tag wrong tests")
 {
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   REQUIRE_THROWS_AS(manager.assign_tags("f89ac3e", "author:Unknown"),
                     libtocc::DatabaseScriptExecutionError);

--- a/libtocc/tests/front_end/front_end_delete_file_tests.cpp
+++ b/libtocc/tests/front_end/front_end_delete_file_tests.cpp
@@ -29,69 +29,69 @@ TEST_CASE("front_end: delete file")
 {
   // Creating a file to import.
   std::ofstream file_stream1;
-  file_stream1.open("/tmp/tocc_test_file_to_delete_1");
+  file_stream1.open("/tmp/tocctests/tocc_test_file_to_delete_1");
   file_stream1 << "data...";
   file_stream1.close();
 
   // Creating a file to import.
   std::ofstream file_stream2;
-  file_stream2.open("/tmp/tocc_test_file_to_delete_2");
+  file_stream2.open("/tmp/tocctests/tocc_test_file_to_delete_2");
   file_stream2 << "data...";
   file_stream2.close();
 
   //Creating files for collection
   std::ofstream file_stream3;
-  file_stream3.open("/tmp/tocc_test_file_to_delete_3");
+  file_stream3.open("/tmp/tocctests/tocc_test_file_to_delete_3");
   file_stream3 << "data...";
   file_stream3.close();
 
   std::ofstream file_stream4;
-  file_stream4.open("/tmp/tocc_test_file_to_delete_4");
+  file_stream4.open("/tmp/tocctests/tocc_test_file_to_delete_4");
   file_stream4 << "data...";
   file_stream4.close();
 
   std::ofstream file_stream5;
-  file_stream5.open("/tmp/tocc_test_file_to_delete_5");
+  file_stream5.open("/tmp/tocctests/tocc_test_file_to_delete_5");
   file_stream5 << "data...";
   file_stream5.close();
 
   //Creating files for array's ids
   std::ofstream file_stream6;
-  file_stream6.open("/tmp/tocc_test_file_to_delete_6");
+  file_stream6.open("/tmp/tocctests/tocc_test_file_to_delete_6");
   file_stream6 << "data...";
   file_stream6.close();
 
   std::ofstream file_stream7;
-  file_stream7.open("/tmp/tocc_test_file_to_delete_7");
+  file_stream7.open("/tmp/tocctests/tocc_test_file_to_delete_7");
   file_stream7 << "data...";
   file_stream7.close();
 
   std::ofstream file_stream8;
-  file_stream8.open("/tmp/tocc_test_file_to_delete_8");
+  file_stream8.open("/tmp/tocctests/tocc_test_file_to_delete_8");
   file_stream8 << "data...";
   file_stream8.close();
 
   // Creating an instance of the manager.
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   // Importing the file
   libtocc::FileInfo test_file1 =
-      manager.import_file("/tmp/tocc_test_file_to_delete_1");
+      manager.import_file("/tmp/tocctests/tocc_test_file_to_delete_1");
 
   libtocc::FileInfo test_file2 =
-      manager.import_file("/tmp/tocc_test_file_to_delete_2");
+      manager.import_file("/tmp/tocctests/tocc_test_file_to_delete_2");
 
   std::string file_id = std::string(test_file1.get_id());
 
   //FileInfoCollection
   libtocc::FileInfo test_file3 =
-      manager.import_file("/tmp/tocc_test_file_to_delete_3");
+      manager.import_file("/tmp/tocctests/tocc_test_file_to_delete_3");
 
   libtocc::FileInfo test_file4 =
-      manager.import_file("/tmp/tocc_test_file_to_delete_4");
+      manager.import_file("/tmp/tocctests/tocc_test_file_to_delete_4");
 
   libtocc::FileInfo test_file5 =
-      manager.import_file("/tmp/tocc_test_file_to_delete_5");
+      manager.import_file("/tmp/tocctests/tocc_test_file_to_delete_5");
 
   libtocc::FileInfo test_file_infos[] = { test_file3, test_file4 };
 
@@ -99,13 +99,13 @@ TEST_CASE("front_end: delete file")
 
   //File ids array
   libtocc::FileInfo test_file6 =
-      manager.import_file("/tmp/tocc_test_file_to_delete_6");
+      manager.import_file("/tmp/tocctests/tocc_test_file_to_delete_6");
 
   libtocc::FileInfo test_file7 =
-      manager.import_file("/tmp/tocc_test_file_to_delete_7");
+      manager.import_file("/tmp/tocctests/tocc_test_file_to_delete_7");
 
   libtocc::FileInfo test_file8 =
-      manager.import_file("/tmp/tocc_test_file_to_delete_8");
+      manager.import_file("/tmp/tocctests/tocc_test_file_to_delete_8");
 
   std::string file_id6 = std::string(test_file6.get_id());
   std::string file_id7 = std::string(test_file7.get_id());

--- a/libtocc/tests/front_end/front_end_get_tests.cpp
+++ b/libtocc/tests/front_end/front_end_get_tests.cpp
@@ -25,7 +25,7 @@
 
 TEST_CASE("Manager::get tests")
 {
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   SECTION("file not found error")
   {

--- a/libtocc/tests/front_end/front_end_import_file_tests.cpp
+++ b/libtocc/tests/front_end/front_end_import_file_tests.cpp
@@ -29,18 +29,18 @@ TEST_CASE("front_end: file import")
 {
   // Creating a file to import.
   std::ofstream file_stream;
-  file_stream.open("/tmp/tocc_test_file_to_import_2");
+  file_stream.open("/tmp/tocctests/tocc_test_file_to_import_2");
   file_stream << "some data...";
   file_stream.close();
 
   // Creating an instance of the manager.
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   SECTION("Importing a file with no property")
   {
     // Importing the file with no property.
     libtocc::FileInfo test_file =
-        manager.import_file("/tmp/tocc_test_file_to_import_2");
+        manager.import_file("/tmp/tocctests/tocc_test_file_to_import_2");
     // Checking if it's OK.
     REQUIRE(strcmp(test_file.get_title(), "tocc_test_file_to_import_2") == 0);
     REQUIRE(strcmp(test_file.get_traditional_path(), "") == 0);
@@ -57,7 +57,7 @@ TEST_CASE("front_end: file import")
   SECTION("Importing the file with Title and Traditional Path")
   {
     libtocc::FileInfo test_file_2 =
-        manager.import_file("/tmp/tocc_test_file_to_import_2",
+        manager.import_file("/tmp/tocctests/tocc_test_file_to_import_2",
                             "Title of the test file",
                             "/home/not_well_organized/test");
     // Checking if it's OK.
@@ -79,7 +79,7 @@ TEST_CASE("front_end: file import")
     tags.add_tag("test");
     tags.add_tag("safe-to-remove");
     libtocc::FileInfo test_file_3 =
-        manager.import_file("/tmp/tocc_test_file_to_import_2",
+        manager.import_file("/tmp/tocctests/tocc_test_file_to_import_2",
                             "Third import",
                             "/home/not_well_organized/test3",
                             &tags);
@@ -118,7 +118,7 @@ TEST_CASE("front_end: file import")
 TEST_CASE("Importing a not-existed file")
 {
   // Creating an instance of the manager.
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   REQUIRE_THROWS_AS(
       manager.import_file("/path/to/a/not/existed/file/fly364bouqc"),

--- a/libtocc/tests/front_end/front_end_import_utf_file_tests.cpp
+++ b/libtocc/tests/front_end/front_end_import_utf_file_tests.cpp
@@ -29,18 +29,18 @@ TEST_CASE("front_end: UTF file import")
 {
   // Creating a file to import.
   std::ofstream file_stream;
-  file_stream.open("/tmp/测试导入文件");
+  file_stream.open("/tmp/tocctests/测试导入文件");
   file_stream << "some data...";
   file_stream.close();
 
   // Creating an instance of the manager.
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   SECTION("Importing a UTF file with no property")
   {
     // Importing the file with no property.
     libtocc::FileInfo test_file =
-        manager.import_file("/tmp/测试导入文件");
+        manager.import_file("/tmp/tocctests/测试导入文件");
     // Checking if it's OK.
     REQUIRE(strcmp(test_file.get_title(), "测试导入文件") == 0);
     REQUIRE(strcmp(test_file.get_traditional_path(), "") == 0);
@@ -57,7 +57,7 @@ TEST_CASE("front_end: UTF file import")
   SECTION("Importing the UTF file with Title and Traditional Path")
   {
     libtocc::FileInfo test_file_2 =
-        manager.import_file("/tmp/测试导入文件",
+        manager.import_file("/tmp/tocctests/测试导入文件",
                             "测试",
                             "/home/someone/测试文件");
     // Checking if it's OK.
@@ -79,7 +79,7 @@ TEST_CASE("front_end: UTF file import")
     tags.add_tag("اختبار");
     tags.add_tag("L'Hôpital");
     libtocc::FileInfo test_file_3 =
-        manager.import_file("/tmp/测试导入文件",
+        manager.import_file("/tmp/tocctests/测试导入文件",
                             "検査",
                             "/home/L'Hôpital/тестирование",
                             &tags);
@@ -118,7 +118,7 @@ TEST_CASE("front_end: UTF file import")
 TEST_CASE("Importing a not-existed UTF file")
 {
   // Creating an instance of the manager.
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   REQUIRE_THROWS_AS(
       manager.import_file("/مجلد/από/ոչ/存在的/फ़ाइल/fうんこ"),

--- a/libtocc/tests/front_end/front_end_set_file_title.cpp
+++ b/libtocc/tests/front_end/front_end_set_file_title.cpp
@@ -32,22 +32,22 @@ TEST_CASE("front_end: set files title tests")
   //Creating files
 
   std::ofstream file_stream1;
-  file_stream1.open("/tmp/tocc_test_random_file_1");
+  file_stream1.open("/tmp/tocctests/tocc_test_random_file_1");
   file_stream1 << "I'm file 1";
   file_stream1.close();
 
   // Creating a file to import.
   std::ofstream file_stream2;
-  file_stream1.open("/tmp/tocc_test_random_file_2");
+  file_stream1.open("/tmp/tocctests/tocc_test_random_file_2");
   file_stream1 << "I'm file 2";
   file_stream1.close();
 
   // Creating an instance of the manager.
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   // Creating 2 files with a title and a traditional path.
-  libtocc::FileInfo new_file1 = manager.import_file("/tmp/tocc_test_random_file_1");
-  libtocc::FileInfo new_file2 = manager.import_file("/tmp/tocc_test_random_file_2");
+  libtocc::FileInfo new_file1 = manager.import_file("/tmp/tocctests/tocc_test_random_file_1");
+  libtocc::FileInfo new_file2 = manager.import_file("/tmp/tocctests/tocc_test_random_file_2");
 
   //Setting the title of the first file
   manager.set_title(new_file1.get_id(), "new title 1");

--- a/libtocc/tests/front_end/front_end_tag_statistics_tests.cpp
+++ b/libtocc/tests/front_end/front_end_tag_statistics_tests.cpp
@@ -28,14 +28,14 @@
 
 TEST_CASE("Tag Statistics")
 {
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   SECTION("Single File")
   {
     /*
      * Preparing test data.
      */
-    const char* file_path = "/tmp/tocc_statistics_test_file.tmp";
+    const char* file_path = "/tmp/tocctests/tocc_statistics_test_file.tmp";
 
     std::ofstream file_to_import(file_path);
     file_to_import << "some data...";
@@ -75,7 +75,7 @@ TEST_CASE("Tag Statistics")
     /*
      * Creating test file.
      */
-    const char* file_path = "/tmp/tocc_statistics_test_file_ufHf89.tmp";
+    const char* file_path = "/tmp/tocctests/tocc_statistics_test_file_ufHf89.tmp";
     std::ofstream file_to_import(file_path);
     file_to_import << "some data...";
     file_to_import.close();

--- a/libtocc/tests/front_end/query_files_tests.cpp
+++ b/libtocc/tests/front_end/query_files_tests.cpp
@@ -29,7 +29,7 @@
 
 TEST_CASE("query_files_tests: simple tag search")
 {
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   SECTION("Assign and search 'test_tag_0xUi7'")
   {
@@ -91,16 +91,16 @@ TEST_CASE("query_files_tests: simple tag search")
 
 TEST_CASE("query_files_tests: simple title search")
 {
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
   SECTION("Import and query `IMG007'")
   {
     std::ofstream file_stream;
-    file_stream.open("/tmp/XlfYru129384PxQ");
+    file_stream.open("/tmp/tocctests/XlfYru129384PxQ");
     file_stream << "Not a real photo!";
     file_stream.close();
 
-    libtocc::FileInfo original_file = manager.import_file("/tmp/XlfYru129384PxQ", "IMG007");
+    libtocc::FileInfo original_file = manager.import_file("/tmp/tocctests/XlfYru129384PxQ", "IMG007");
 
     libtocc::Title title_expr("IMG007");
     libtocc::And main_and(title_expr);
@@ -122,9 +122,9 @@ TEST_CASE("query_files_tests: simple title search")
 
 TEST_CASE("query_files_tests: long query test")
 {
-  libtocc::Manager manager("/tmp/");
+  libtocc::Manager manager("/tmp/tocctests/");
 
-  std::string test_file = "/tmp/iU83FpdAdjcAppfkdj";
+  std::string test_file = "/tmp/tocctests/iU83FpdAdjcAppfkdj";
 
   std::ofstream file_stream;
   file_stream.open(test_file.c_str());

--- a/libtocc/tests/main.cpp
+++ b/libtocc/tests/main.cpp
@@ -24,3 +24,30 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
+#include <iostream>
+
+/*
+** Initialisation of Library
+*/
+class TestInitialiser
+{
+  public:
+    TestInitialiser()
+    {
+      // clean previous test files
+      if (int status = system("rm -rf /tmp/tocctests"))
+      {
+        std::cout << "Test initialisation failed -\
+          Unable to delete files" << std::endl;
+        exit(status);
+      }
+      else if (int status = system("mkdir /tmp/tocctests"))
+      {
+        std::cout << "Test initialisation failed -\
+          Unable to create base directory" << std::endl;
+        exit(status);
+      }
+    };
+};
+
+TestInitialiser now;


### PR DESCRIPTION
base path for tests is relocated to /tmp/tocctests.

tried to define base variable for easier control,
gave up later due to extensive existing uses of c-style string.

now everything is simply hard-coded.
